### PR TITLE
FIXED: Build failure.

### DIFF
--- a/org.swi_prolog.swipl.yml
+++ b/org.swi_prolog.swipl.yml
@@ -16,11 +16,11 @@ modules:
     sources:
       - type: git
         url: https://github.com/SWI-Prolog/swipl-devel.git
-        tag: V9.3.22
-        commit: c35d716a76178dc1d4f062293ef7c82354154376
-        x-checker-data:
-          type: git
-          tag-pattern: ^V(\d\.[\d.]+)$
+        # tag: V9.3.22
+        commit: 3120ee45b92f6369d672b4662a97448595b0a480
+        # x-checker-data:
+        #   type: git
+        #   tag-pattern: ^V(\d\.[\d.]+)$
       - type: file
         path: org.swi_prolog.swipl.desktop
       - type: file

--- a/org.swi_prolog.swipl.yml
+++ b/org.swi_prolog.swipl.yml
@@ -28,10 +28,11 @@ modules:
       - type: file
         path: org.swi_prolog.swipl.png
     buildsystem: cmake-ninja
+    builddir: true
     config-opts:
       - -DCMAKE_BUILD_TYPE=PGO
       - -DSKIP_SSL_TESTS=ON
     post-install:
-      - install -D -m0644 org.swi_prolog.swipl.png /app/share/icons/hicolor/128x128/apps/org.swi_prolog.swipl.png
-      - install -D -m0644 org.swi_prolog.swipl.desktop /app/share/applications/org.swi_prolog.swipl.desktop
-      - install -D -m0644 org.swi_prolog.swipl.appdata.xml /app/share/metainfo/org.swi_prolog.swipl.appdata.xml
+      - install -D -m0644 ../org.swi_prolog.swipl.png /app/share/icons/hicolor/128x128/apps/org.swi_prolog.swipl.png
+      - install -D -m0644 ../org.swi_prolog.swipl.desktop /app/share/applications/org.swi_prolog.swipl.desktop
+      - install -D -m0644 ../org.swi_prolog.swipl.appdata.xml /app/share/metainfo/org.swi_prolog.swipl.appdata.xml


### PR DESCRIPTION
The system was build in the main source dir.   This causes the qlf
build process to compile too many files and run into trouble.

This fixes the build issue.    But, there are several other issues that result from the move to install the libraries as .qlf files.   These are now mostly resolved the current GIT source.   I plan to release 9.3.24 once the remaining issues are resolved.   You get a mostly working installation from SWI-Prolog/swipl-devel@3120ee45b92f6369d672b4662a97448595b0a480