### PR TITLE
Update runtime to 25.08, cleanup modules

### DIFF
--- a/org.swi_prolog.swipl.yml
+++ b/org.swi_prolog.swipl.yml
@@ -1,6 +1,6 @@
 id: org.swi_prolog.swipl
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 command: swipl-win
 
@@ -15,45 +15,17 @@ finish-args:
   - --device=dri
 
 modules:
-  - name: SDL3
-    buildsystem: cmake-ninja
-    config-opts:
-      - -DSDL_TEST=OFF
-      - -DSDL_SHARED=ON
-    sources:
-      - type: git
-        url: https://github.com/libsdl-org/SDL.git
-        commit: 68bfcb6c5419f51104e74e72ea0f8d405a4615b0
-
-  - name: SDL3_image
-    buildsystem: cmake-ninja
-    config-opts:
-      - -DCMAKE_BUILD_TYPE=Release
-      - -DSDLIMAGE_BACKEND_IMAGEIO=ON
-      - -DSDLIMAGE_BACKEND_STB=ON
-      - -DSDLIMAGE_JPG=ON
-      - -DSDLIMAGE_PNG=ON
-      - -DSDLIMAGE_WEBP=OFF
-    sources:
-      - type: git
-        url: https://github.com/libsdl-org/SDL_image
-        commit: 11154afb7855293159588b245b446a4ef09e574f
-
   - name: libedit
     sources:
       - type: archive
         url: https://thrysoee.dk/editline/libedit-20250104-3.1.tar.gz
         sha256: 23792701694550a53720630cd1cd6167101b5773adddcb4104f7345b73a568ac
-    buildsystem: autotools
 
   - name: libyaml
-    buildsystem: autotools
     sources:
       - type: git
         url: https://github.com/yaml/libyaml
         commit: 840b65c40675e2d06bf40405ad3f12dec7f35923
-    build-commands:
-      - ./bootstrap
 
   - name: fix-compose
     buildsystem: simple


### PR DESCRIPTION
SDL3 is part of the runtime since 25.08. `buildsystem: autotools` is default and can be removed. The `bootstrap` script for libyaml also appears to be unnecessary.